### PR TITLE
Publish events to event type

### DIFF
--- a/client/Pages/EventTypeDetails/Messages.elm
+++ b/client/Pages/EventTypeDetails/Messages.elm
@@ -43,3 +43,4 @@ type Msg
     | EditEvent String
     | SendEvent
     | SendEventResponse (WebData String)
+    | SendEventReset

--- a/client/Pages/EventTypeDetails/Messages.elm
+++ b/client/Pages/EventTypeDetails/Messages.elm
@@ -10,7 +10,7 @@ import Stores.Partition
 import Stores.EventTypeSchema
 import Stores.EventTypeValidation
 import Http
-
+import RemoteData exposing (WebData)
 
 type Msg
     = OnRouteChange Route
@@ -40,3 +40,6 @@ type Msg
     | OutAddToFavorite String
     | OutRemoveFromFavorite String
     | ValidationStoreMsg Stores.EventTypeValidation.Msg
+    | EditEvent String
+    | SendEvent
+    | SendEventResponse (WebData String)

--- a/client/Pages/EventTypeDetails/Models.elm
+++ b/client/Pages/EventTypeDetails/Models.elm
@@ -11,6 +11,8 @@ import Stores.CursorDistance
 import Stores.EventTypeSchema
 import Stores.EventTypeValidation
 import Helpers.Store exposing (Status(Unknown), ErrorMessage)
+import Http
+import RemoteData exposing (WebData, RemoteData(NotAsked))
 
 
 initialModel : Model
@@ -27,6 +29,8 @@ initialModel =
     , eventTypeSchemasStore = Stores.EventTypeSchema.initialModel
     , totalsStore = Stores.CursorDistance.initialModel
     , validationIssuesStore = Stores.EventTypeValidation.initialModel
+    , editEvent = emptyString
+    , sendEventResponse = NotAsked
     , deletePopup =
         { isOpen = False
         , deleteCheckbox = False
@@ -42,6 +46,7 @@ type Tabs
     | PublisherTab
     | ConsumerTab
     | AuthTab
+    | PublishTab
 
 
 type alias Model =
@@ -57,6 +62,8 @@ type alias Model =
     , eventTypeSchemasStore : Stores.EventTypeSchema.Model
     , totalsStore : Stores.CursorDistance.Model
     , validationIssuesStore : Stores.EventTypeValidation.Model
+    , editEvent : String
+    , sendEventResponse : WebData String
     , deletePopup :
         { isOpen : Bool
         , deleteCheckbox : Bool
@@ -131,6 +138,9 @@ stringToTabs str =
 
         "AuthTab" ->
             Just AuthTab
+
+        "PublishTab" ->
+            Just PublishTab
 
         _ ->
             Nothing

--- a/client/Pages/EventTypeDetails/PublishTab.elm
+++ b/client/Pages/EventTypeDetails/PublishTab.elm
@@ -7,8 +7,9 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Helpers.UI exposing (..)
-import Helpers.Panel exposing (renderError)
+import Helpers.Panel exposing (renderError, warningMessage)
 import Helpers.Store exposing (errorToViewRecord)
+import Helpers.JsonPrettyPrint exposing (prettyPrintJson)
 import RemoteData exposing (WebData, isLoading)
 import Http
 import Json.Decode
@@ -111,7 +112,15 @@ showRemoteDataStatus state =
             div [] [ text "Publishing..." ]
 
         RemoteData.Success resp ->
-            div [ class "dc--text-success" ] [ text ("Event(s) succsessfuly published! " ++ resp) ]
+            if String.isEmpty resp then
+                div [ class "dc--text-success" ] [ text ("Event(s) succsessfuly published!") ]
+            else
+                warningMessage
+                    "Unexpected server response"
+                    "Probably not all events are published successfuly"
+                    (Just
+                        (pre [ class "dc-pre" ] [ text (prettyPrintJson resp) ])
+                    )
 
         RemoteData.Failure resp ->
             resp |> errorToViewRecord |> renderError

--- a/client/Pages/EventTypeDetails/PublishTab.elm
+++ b/client/Pages/EventTypeDetails/PublishTab.elm
@@ -1,0 +1,117 @@
+module Pages.EventTypeDetails.PublishTab exposing (..)
+
+import Pages.EventTypeDetails.Models exposing (Model)
+import Pages.EventTypeDetails.Messages exposing (..)
+import RemoteData
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Helpers.UI exposing (..)
+import Helpers.Panel exposing (renderError)
+import Helpers.Store exposing (errorToViewRecord)
+import RemoteData exposing (WebData, isLoading)
+import Http
+import Json.Decode
+import Config
+import Result
+
+
+publishTab : Model -> Html Msg
+publishTab pageState =
+    let
+        jsonParsed =
+            (Json.Decode.decodeString Json.Decode.value pageState.editEvent)
+
+        jsonError =
+            if String.isEmpty pageState.editEvent then
+                ""
+            else
+                case jsonParsed of
+                    Ok _ ->
+                        ""
+
+                    Err err ->
+                        err
+
+        isDisabled =
+            (isLoading pageState.sendEventResponse)
+                || (Result.toMaybe jsonParsed == Nothing)
+                || (String.isEmpty pageState.editEvent)
+
+        classDisabled =
+            if isDisabled then
+                "dc-btn--disabled"
+            else
+                ""
+
+        aPlaceholder =
+            """
+Example:
+[
+  {
+      "metadata":{
+        "occurred_at":"2018-08-11T16:39:57+02:00",
+        "eid":"77669179-ef95-41b8-9c04-ee84685e0f21",
+      },
+      "business_id":"ABC-1"
+  }
+]
+"""
+    in
+        div [ class "dc-card" ]
+            [ h3 [ class "dc-h3" ] [ text "Publish event to this Event Type" ]
+            , p [ class "dc--text-less-important" ] [ text "Expectd JSON array of events. Example: [{\"order_id\": \"1052\"}, {\"order_id\": \"8364\"}]" ]
+            , div []
+                [ textarea
+                    [ onInput EditEvent
+                    , placeholder aPlaceholder
+                    , value pageState.editEvent
+                    , rows 15
+                    , class "dc-textarea"
+                    ]
+                    []
+                ]
+            , div [ class "dc--text-error" ] [ text jsonError ]
+            , showRemoteDataStatus pageState.sendEventResponse
+            , div []
+                [ button [ onClick SendEvent, disabled isDisabled, class ("dc-btn dc-btn--primary " ++ classDisabled) ] [ text "Send" ]
+                , span [ class "dc--island-100" ] []
+                , button [ onClick SendEventReset, class "dc-btn " ] [ text "Reset" ]
+                ]
+            ]
+
+
+sendEvent : (WebData String -> msg) -> String -> String -> Cmd msg
+sendEvent tagger name event =
+    case (Json.Decode.decodeString Json.Decode.value event) of
+        Ok val ->
+            Http.request
+                { method = "POST"
+                , headers = []
+                , url = Config.urlNakadiApi ++ "event-types/" ++ (Http.encodeUri name) ++ "/events"
+                , body = Http.jsonBody val
+                , expect = Http.expectString
+                , timeout = Nothing
+                , withCredentials = False
+                }
+                |> RemoteData.sendRequest
+                |> Cmd.map tagger
+
+        Err err ->
+            Debug.log ("event JSON decode error:" ++ err) Cmd.none
+
+
+showRemoteDataStatus : WebData String -> Html Msg
+showRemoteDataStatus state =
+    case state of
+        RemoteData.NotAsked ->
+            div [] [ none ]
+
+        RemoteData.Loading ->
+            div [] [ text "Publishing..." ]
+
+        RemoteData.Success resp ->
+            div [ class "dc--text-success" ] [ text ("Event(s) succsessfuly published! " ++ resp) ]
+
+        RemoteData.Failure resp ->
+            resp |> errorToViewRecord |> renderError

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -28,6 +28,7 @@ import Stores.EventTypeValidation exposing (EventTypeValidationIssue)
 import Pages.EventTypeDetails.Messages exposing (..)
 import Pages.EventTypeDetails.Models exposing (Tabs(..), Model)
 import Pages.EventTypeDetails.Help as Help
+import Pages.EventTypeDetails.PublishTab exposing (publishTab)
 import Pages.EventTypeDetails.EffectiveSchema exposing (toEffective)
 import Pages.EventTypeList.Models
 import Pages.Partition.Models
@@ -53,7 +54,6 @@ import Helpers.UI
         , newline
         , popup
         )
-import RemoteData
 
 
 view : AppModel -> Html Msg
@@ -244,7 +244,7 @@ detailsLayout typeName eventType model =
                                 eventType
                           )
                         , ( PublishTab
-                          , "Publish"
+                          , "Publish Events"
                           , publishTab pageState
                           )
                         ]
@@ -580,32 +580,6 @@ renderPublishers name appsInfoUrl usersInfoUrl item =
         , td [ class "dc-table__td" ] [ text (toString item.count) ]
         , td [ class "dc-table__td" ]
             []
-        ]
-
-
-publishTab : Model -> Html Msg
-publishTab pageState =
-    div [ class "dc-card" ]
-        [ h3 [ class "dc-h3" ] [ text "Publish event to this Event Type" ]
-        , div [ class "dc-card" ]
-            [ textarea [ onInput EditEvent, value pageState.editEvent, rows 10, class "dc-textarea" ] []
-            ]
-        , case pageState.sendEventResponse of
-            RemoteData.NotAsked ->
-                div [ class "dc-card" ] [ none ]
-
-            RemoteData.Loading ->
-                div [ class "dc-card" ] [ text "Loadding..." ]
-
-            RemoteData.Success resp ->
-                div [ class "dc-card" ] [ text ("Events succsessfuly published! " ++ resp) ]
-
-            RemoteData.Failure resp ->
-                div [ class "dc-card" ] [ text (toString resp) ]
-        , div [ class "dc-card" ]
-            [ button [ onClick SendEvent, class "dc-btn dc-btn--primary" ] [ text "Send" ]
-            , button [ class "dc-btn " ] [ text "Reset" ]
-            ]
         ]
 
 

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -53,6 +53,7 @@ import Helpers.UI
         , newline
         , popup
         )
+import RemoteData
 
 
 view : AppModel -> Html Msg
@@ -220,7 +221,7 @@ detailsLayout typeName eventType model =
                           )
                         , ( PublisherTab
                           , "Publishers"
-                          , publishTab
+                          , publisherTab
                                 eventType
                                 pageState.publishersStore
                                 appsInfoUrl
@@ -241,6 +242,10 @@ detailsLayout typeName eventType model =
                                 appsInfoUrl
                                 usersInfoUrl
                                 eventType
+                          )
+                        , ( PublishTab
+                          , "Publish"
+                          , publishTab pageState
                           )
                         ]
                     ]
@@ -541,8 +546,8 @@ renderPartition totalsStore name partition =
             ]
 
 
-publishTab : EventType -> Stores.Publisher.Model -> String -> String -> Html Msg
-publishTab eventType publishersStore appsInfoUrl usersInfoUrl =
+publisherTab : EventType -> Stores.Publisher.Model -> String -> String -> Html Msg
+publisherTab eventType publishersStore appsInfoUrl usersInfoUrl =
     let
         publishersList =
             Store.items publishersStore
@@ -575,6 +580,32 @@ renderPublishers name appsInfoUrl usersInfoUrl item =
         , td [ class "dc-table__td" ] [ text (toString item.count) ]
         , td [ class "dc-table__td" ]
             []
+        ]
+
+
+publishTab : Model -> Html Msg
+publishTab pageState =
+    div [ class "dc-card" ]
+        [ h3 [ class "dc-h3" ] [ text "Publish event to this Event Type" ]
+        , div [ class "dc-card" ]
+            [ textarea [ onInput EditEvent, value pageState.editEvent, rows 10, class "dc-textarea" ] []
+            ]
+        , case pageState.sendEventResponse of
+            RemoteData.NotAsked ->
+                div [ class "dc-card" ] [ none ]
+
+            RemoteData.Loading ->
+                div [ class "dc-card" ] [ text "Loadding..." ]
+
+            RemoteData.Success resp ->
+                div [ class "dc-card" ] [ text ("Events succsessfuly published! " ++ resp) ]
+
+            RemoteData.Failure resp ->
+                div [ class "dc-card" ] [ text (toString resp) ]
+        , div [ class "dc-card" ]
+            [ button [ onClick SendEvent, class "dc-btn dc-btn--primary" ] [ text "Send" ]
+            , button [ class "dc-btn " ] [ text "Reset" ]
+            ]
         ]
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -22,7 +22,6 @@
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
         "krisajenkins/remotedata": "4.5.0 <= v < 5.0.0",
-        "lukewestby/elm-http-builder": "5.2.0 <= v < 6.0.0",
         "ohanhi/keyboard-extra": "1.2.0 <= v < 2.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
         "thaterikperson/elm-strftime": "1.0.1 <= v < 2.0.0"

--- a/elm-package.json
+++ b/elm-package.json
@@ -21,6 +21,8 @@
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
+        "krisajenkins/remotedata": "4.5.0 <= v < 5.0.0",
+        "lukewestby/elm-http-builder": "5.2.0 <= v < 6.0.0",
         "ohanhi/keyboard-extra": "1.2.0 <= v < 2.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
         "thaterikperson/elm-strftime": "1.0.1 <= v < 2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,14 +2466,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2488,20 +2486,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2618,8 +2613,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2631,7 +2625,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2646,7 +2639,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2654,14 +2646,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2680,7 +2670,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2761,8 +2750,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2774,7 +2762,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2896,7 +2883,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/tests/mocks/data/error207.json
+++ b/tests/mocks/data/error207.json
@@ -1,0 +1,9 @@
+[{
+  "eid":"321-2345-43534634564",
+  "publishing_status": "submitted"
+},{
+ "eid":"123-2345-43534634564",
+ "publishing_status": "failed",
+ "step":"validating",
+ "detail": "kill all humans"
+}]

--- a/tests/mocks/testNakadi.js
+++ b/tests/mocks/testNakadi.js
@@ -11,6 +11,7 @@ const cursors = require('./data/cursors.json');
 const error404 = require('./data/error404.json');
 const error412 = require('./data/error412.json');
 const error400 = require('./data/error400.json');
+const error207 = require('./data/error207.json');
 
 const app = express();
 app.use(bodyParser.json()); // for parsing application/json
@@ -96,7 +97,7 @@ app.get('/event-types/:name/events', (req, res) => {
 });
 
 app.post('/event-types/:name/events', (req, res) => {
-    res.json({})
+    res.status(207).json(error207)
 });
 
 app.get('/event-types/:name/schemas', (req, res) => {


### PR DESCRIPTION
A new tab "Publish Event" added to the event type details page.
It allows the user to publish a batch of events to a selected event type.
It should help to test/debug consumers, test/debug event type schemas, manually fire processing workflows.
![screenshot 38](https://user-images.githubusercontent.com/3240529/44105312-922d8f4e-9ff1-11e8-8ba8-8ddc7bc613d4.png)

In case of server-side error, the error message shows the details.
![screenshot 39](https://user-images.githubusercontent.com/3240529/44105465-224ad8ca-9ff2-11e8-9b5f-e8ed67304db2.png)
