### PR TITLE
#11 Configurable scalyr request.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ SUBSCRIPTION_MONITORING_URL="https://zmon.example.com/grafana/dashboard/db/nakad
 
 SCALYR_URL="https://www.scalyr.com/api/"
 SCALYR_KEY="123_secret_123"
+SCALYR_BASE_FILTER=($serverHost=="nakadi") and ($logfile=="/var/log/application.log") and
 
 AUTH_STRATEGY="passport-google-oauth20"
 AUTH_OPTIONS_clientID="some client id.apps.googleusercontent.com"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,6 +95,7 @@ SUPPORT_URL=https://hipchat.example.com/chat/room/12345
 # Required
 SCALYR_URL="https://www.scalyr.com/api/"
 SCALYR_KEY="YOUR-SCALYR-API-KEY-3c9f8h3e8b3d07e-"
+SCALYR_BASE_FILTER=($serverHost=="nakadi") and ($logfile=="/var/log/application.log") and
 
 # Feature flags.
 # Optional, default "No"

--- a/server/config.js
+++ b/server/config.js
@@ -52,6 +52,7 @@ exports = module.exports = function createConfiguration(env) {
         logsApi: {
             scalyrUrl: required('SCALYR_URL', env),
             scalyrKey: required('SCALYR_KEY', env),
+            scalyrBaseFilter: optional('SCALYR_BASE_FILTER', env, '($serverHost=="nakadi") and ($logfile=="/var/log/application.log") and ')
         },
         cookie: {
             cookieName: 'session', // cookie name dictates the key name added to the request object

--- a/server/logsApi.js
+++ b/server/logsApi.js
@@ -17,12 +17,13 @@ const ERROR = 502;
  * @param {Object} options
  * @param {String} options.scalyrUrl
  * @param {String} options.scalyrKey
+ * @param {String} options.scalyrBaseFilter
  *
  * @returns {Router}
  */
 module.exports = function logsApi(options) {
     const defaults = {
-        filter: '($serverHost=="nakadi") and ($logfile=="/var/log/application.log") and ',
+        filter: options.scalyrBaseFilter,
         scalyrUrl: '',
         scalyrKey: ''
     };

--- a/tests/end2end/createSubscriptionForm.spec.js
+++ b/tests/end2end/createSubscriptionForm.spec.js
@@ -14,7 +14,7 @@ describe('Create Subscription form', function() {
         .waitForVisible('h4=Welcome to Nakadi, a distributed, open-source event messaging service!', 1000)
         .click('button=Create')
         .click('a=Subscription')
-        .waitForVisible('h4=Create Subscription', 1000)
+        .waitForVisible('h4=Create Subscription', 10000)
         .click('#subscriptionCreateFormFieldConsumerGroup')
         .isEnabled('button=Create Subscription').then(function(enabled) {
             expect(enabled).toBeFalsy('Submit btn should be disabled by default')

--- a/tests/unit/config.spec.js
+++ b/tests/unit/config.spec.js
@@ -27,6 +27,7 @@ describe('Config', function() {
             AUTHORIZE_OPTIONS_scope: 'myscope',
             SCALYR_URL: "https://www.scalyr.com/api/",
             SCALYR_KEY: "somekey",
+            SCALYR_BASE_FILTER: "($serverHost==\"nakadi-staging\") and ($logfile==\"/var/log/application.log\") and",
             ANALYTICS_STRATEGY: "some-plugin",
             ANALYTICS_OPTIONS_url: "https://nakadi-staging.example.com",
             ANALYTICS_OPTIONS_name: "aruha.nakadi-ui.access-log",
@@ -84,6 +85,7 @@ describe('Config', function() {
             logsApi: {
                 scalyrUrl: "https://www.scalyr.com/api/",
                 scalyrKey: "somekey",
+                scalyrBaseFilter: "($serverHost==\"nakadi-staging\") and ($logfile==\"/var/log/application.log\") and",
             },
             cookie: {
                 cookieName: 'session',


### PR DESCRIPTION
#11 Configurable Scalyr request.
New optional configuration parameter `SCALYR_BASE_FILTER` added. 
It is used to preselect log messages before finding consumers or producers of an event type.
This helps to adapt UI to different Scalyr setups.
Default value is the same.
`($serverHost=="nakadi") and ($logfile=="/var/log/application.log") and`
For staging, for example, it can be
`(($serverHost=="nakadi-staging") or ($serverHost=="nakadi-sandbox"))  and ($logfile=="/var/log/application.log") and`