### PR TITLE
#12 make AUDIENCE field required and with blank option

### DIFF
--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -93,7 +93,7 @@ defaultValues =
     , ( FieldRetentionTime, toString defaultRetentionDays )
     , ( FieldSchema, defaultSchema )
     , ( FieldCompatibilityMode, compatibilityModes.forward )
-    , ( FieldAudience, audiences.component_internal )
+    , ( FieldAudience, "" )
     , ( FieldCleanupPolicy, cleanupPolicies.delete )
     ]
         |> List.map (\( field, value ) -> ( toString field, value ))

--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -191,6 +191,7 @@ validate model eventTypeStore =
                 |> isNotEmpty FieldName model
                 |> isNotEmpty FieldOwningApplication model
                 |> isNotEmpty FieldSchema model
+                |> isNotEmpty FieldAudience model
 
         errors =
             case model.operation of

--- a/tests/end2end/createEtForm.spec.js
+++ b/tests/end2end/createEtForm.spec.js
@@ -20,6 +20,10 @@ describe('Create Event type form', function() {
         })
         .input('#eventTypeCreateFormFieldName', eventTypeName)
         .isEnabled('button=Create Event Type').then(function(enabled) {
+            expect(enabled).toBeFalsy('Submit btn should be still disabled if name is set but no Audience selected')
+        })
+        .selectByValue("#eventTypeCreateFormFieldAudience", 'component-internal')
+        .isEnabled('button=Create Event Type').then(function(enabled) {
             expect(enabled).toBeTruthy('Submit btn should be enabled if name is set')
         })
         .click('button=Create Event Type')


### PR DESCRIPTION
#12 make AUDIENCE field required and with the blank option on the create/update Event type form.
The form also was a bit refactored to use semantic specific readable types instead of generic True/False