### PR TITLE
Set current user full access for created ET, Sub and Query

### DIFF
--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -13,17 +13,18 @@ import Regex
 import Json.Decode
 import Helpers.JsonPrettyPrint exposing (prettyPrintJson)
 import Helpers.AccessEditor as AccessEditor
-import Stores.Authorization exposing (Authorization, emptyAuthorization)
+import Stores.Authorization exposing (Authorization, userAuthorization)
 import Constants exposing (emptyString)
 import Stores.EventType exposing (categories, partitionStrategies)
 import Stores.Partition
 import Dom
 import Task
 import Helpers.Forms exposing (..)
+import User.Models exposing (User)
 
 
-update : Msg -> Model -> Stores.EventType.Model -> ( Model, Cmd Msg )
-update message model eventTypeStore =
+update : Msg -> Model -> Stores.EventType.Model -> User -> ( Model, Cmd Msg )
+update message model eventTypeStore user =
     case message of
         OnInput field value ->
             let
@@ -100,16 +101,16 @@ update message model eventTypeStore =
                 authorization =
                     case model.operation of
                         Create ->
-                            authorizationFromEventType Nothing eventTypeStore
+                            authorizationFromEventType Nothing eventTypeStore user.id
 
                         Update name ->
-                            authorizationFromEventType (Just name) eventTypeStore
+                            authorizationFromEventType (Just name) eventTypeStore user.id
 
                         Clone name ->
-                            authorizationFromEventType (Just name) eventTypeStore
+                            authorizationFromEventType (Just name) eventTypeStore user.id
 
                         CreateQuery ->
-                            authorizationFromEventType Nothing eventTypeStore
+                            authorizationFromEventType Nothing eventTypeStore user.id
 
                 loadPartitionsCmd =
                     case model.operation of
@@ -189,12 +190,12 @@ formValuesFromEventType name eventTypeStore =
                 loadValues eventType
 
 
-authorizationFromEventType : Maybe String -> Stores.EventType.Model -> Authorization
-authorizationFromEventType maybeName eventTypeStore =
+authorizationFromEventType : Maybe String -> Stores.EventType.Model -> String -> Authorization
+authorizationFromEventType maybeName eventTypeStore userId =
     maybeName
         |> Maybe.andThen (\name -> Store.get name eventTypeStore)
         |> Maybe.andThen .authorization
-        |> Maybe.withDefault emptyAuthorization
+        |> Maybe.withDefault (userAuthorization userId)
 
 
 validate : Model -> Stores.EventType.Model -> Model

--- a/client/Pages/SubscriptionCreate/Update.elm
+++ b/client/Pages/SubscriptionCreate/Update.elm
@@ -23,8 +23,9 @@ import MultiSearch.Models exposing (SearchItem(SearchItemEventType), Config)
 import List.Extra
 import Helpers.FileReader as FileReader
 import Helpers.AccessEditor as AccessEditor
-import Stores.Authorization exposing (Authorization, emptyAuthorization)
+import Stores.Authorization exposing (Authorization, userAuthorization)
 import Helpers.Forms exposing (..)
+import User.Models exposing (User)
 
 
 searchConfig : Stores.EventType.Model -> Config
@@ -39,8 +40,8 @@ searchConfig eventTypeStore =
     }
 
 
-update : Msg -> Model -> Stores.EventType.Model -> Stores.Subscription.Model -> ( Model, Cmd Msg )
-update message model eventTypeStore subscriptionStore =
+update : Msg -> Model -> Stores.EventType.Model -> Stores.Subscription.Model -> User -> ( Model, Cmd Msg )
+update message model eventTypeStore subscriptionStore user =
     case message of
         OnInput field value ->
             let
@@ -71,7 +72,7 @@ update message model eventTypeStore subscriptionStore =
                     )
 
                 authorization maybeId =
-                    authorizationFromSubscription maybeId subscriptionStore
+                    authorizationFromSubscription maybeId subscriptionStore user.id
 
                 setAuthEditorCmd maybeId =
                     dispatch (AccessEditorMsg (AccessEditor.Set (authorization maybeId)))
@@ -451,9 +452,9 @@ cloneSubscription subscriptionStore id model =
         { initialModel | values = values, cursorsStore = model.cursorsStore, operation = model.operation }
 
 
-authorizationFromSubscription : Maybe String -> Stores.Subscription.Model -> Authorization
-authorizationFromSubscription maybeId subscriptionsStore =
+authorizationFromSubscription : Maybe String -> Stores.Subscription.Model -> String -> Authorization
+authorizationFromSubscription maybeId subscriptionsStore userId =
     maybeId
         |> Maybe.andThen (\id -> Store.get id subscriptionsStore)
         |> Maybe.andThen .authorization
-        |> Maybe.withDefault emptyAuthorization
+        |> Maybe.withDefault (userAuthorization userId)

--- a/client/Stores/Authorization.elm
+++ b/client/Stores/Authorization.elm
@@ -80,6 +80,32 @@ emptyAuthorization =
     }
 
 
+userAuthorization : String -> Authorization
+userAuthorization userId =
+    { readers =
+        [ AuthorizationAttribute
+            User
+            "user"
+            userId
+            (Permission True True True)
+        ]
+    , writers =
+        [ AuthorizationAttribute
+            User
+            "user"
+            userId
+            (Permission True True True)
+        ]
+    , admins =
+        [ AuthorizationAttribute
+            User
+            "user"
+            userId
+            (Permission True True True)
+        ]
+    }
+
+
 
 -- Decoders
 
@@ -116,12 +142,14 @@ encoder authorization =
         , ( "admins", Encode.list (authorization.admins |> List.map encodeAttribute) )
         ]
 
+
 encoderReadAdmin : Authorization -> Encode.Value
 encoderReadAdmin authorization =
     Encode.object
         [ ( "readers", Encode.list (authorization.readers |> List.map encodeAttribute) )
         , ( "admins", Encode.list (authorization.admins |> List.map encodeAttribute) )
         ]
+
 
 encodeAttribute : AuthorizationAttribute -> Encode.Value
 encodeAttribute attr =

--- a/client/Stores/Authorization.elm
+++ b/client/Stores/Authorization.elm
@@ -87,21 +87,21 @@ userAuthorization userId =
             User
             "user"
             userId
-            (Permission True True True)
+            readPermission
         ]
     , writers =
         [ AuthorizationAttribute
             User
             "user"
             userId
-            (Permission True True True)
+            writePermission
         ]
     , admins =
         [ AuthorizationAttribute
             User
             "user"
             userId
-            (Permission True True True)
+            adminPermission
         ]
     }
 

--- a/client/Update.elm
+++ b/client/Update.elm
@@ -180,6 +180,7 @@ updateComponents message model =
                         model.subscriptionCreatePage
                         model.eventTypeStore
                         model.subscriptionStore
+                        model.userStore.user
             in
                 ( { model | subscriptionCreatePage = newModel }, Cmd.map SubscriptionCreateMsg subCmd )
 
@@ -214,7 +215,7 @@ updateComponents message model =
         EventTypeCreateMsg subMsg ->
             let
                 ( newModel, subCmd ) =
-                    PageEventTypeCreate.update subMsg model.eventTypeCreatePage model.eventTypeStore
+                    PageEventTypeCreate.update subMsg model.eventTypeCreatePage model.eventTypeStore model.userStore.user
             in
                 ( { model | eventTypeCreatePage = newModel }, Cmd.map EventTypeCreateMsg subCmd )
 


### PR DESCRIPTION
What: 
Set current user full access for created ET, Sub and Query.
The user can still remove themselves from access list or change permissions.
This feature is only for convenience. 

Why:
Often people forget to set them selfs as an admin of Event types, Subscriptions or Queries created by them in UI. It leads to manual work and distraction as people ask support to give them permissions for their entities.
