### PR TITLE
#22 Fix some event publishing UX problems

### DIFF
--- a/client/Constants.elm
+++ b/client/Constants.elm
@@ -11,6 +11,11 @@ userDateTimeFormat =
     "%b %d %Y, %-I:%M %p"
 
 
+isoDateTimeFormat : String
+isoDateTimeFormat =
+    "%Y-%m-%dT%H:%M:%SZ"
+
+
 emptyString : String
 emptyString =
     ""

--- a/client/Helpers/Panel.elm
+++ b/client/Helpers/Panel.elm
@@ -3,14 +3,15 @@ module Helpers.Panel exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Messages exposing (..)
-import Routing.Models exposing (Route)
-import Routing.Messages exposing (Msg(Redirect))
 import Helpers.Store exposing (Status(..), ErrorMessage)
-import Helpers.UI exposing (none)
 
 
-panel : Int -> String -> List (Html Messages.Msg) -> Html Messages.Msg
+none : Html msg
+none =
+    text ""
+
+
+panel : Int -> String -> List (Html msg) -> Html msg
 panel gridSize title desc =
     div [ class ("dc-column  dc-column dc-column--small-" ++ toString gridSize) ]
         [ div [ class "dc-card dc-column__contents" ]
@@ -21,18 +22,7 @@ panel gridSize title desc =
         ]
 
 
-panelWithButton : Int -> String -> List (Html Messages.Msg) -> String -> Route -> Html Messages.Msg
-panelWithButton gridSize title desc btnText route =
-    panel gridSize
-        title
-        [ p [] desc
-        , div [ class "dc--text-center" ]
-            [ button [ class "dc-btn dc-btn--primary dc--text-center", onClick (RoutingMsg (Redirect route)) ] [ text btnText ]
-            ]
-        ]
-
-
-simplePanel : Int -> String -> List (Html Messages.Msg) -> Html Messages.Msg
+simplePanel : Int -> String -> List (Html msg) -> Html msg
 simplePanel gridSize title desc =
     div [ class "page dc-row dc-row--align--center " ]
         [ div [ class ("dc-column  dc-column dc-column--small-" ++ toString gridSize) ]
@@ -45,7 +35,7 @@ simplePanel gridSize title desc =
         ]
 
 
-page : List Messages.Msg -> List (Html Messages.Msg) -> Html Messages.Msg
+page : List msg -> List (Html msg) -> Html msg
 page attr cols =
     div [ class "page dc-row dc-row--align--center " ] cols
 
@@ -135,7 +125,7 @@ successMessage titleText message maybeMore =
 
 loadingProgress : Html msg
 loadingProgress =
-    div [ class "loading"]
+    div [ class "loading" ]
         [ text "Loading..."
         , div
             [ class "loading-bar dc-loading-bar" ]

--- a/client/Pages/EventTypeCreate/Query.elm
+++ b/client/Pages/EventTypeCreate/Query.elm
@@ -7,7 +7,6 @@ import Http
 import Config
 import Helpers.Forms exposing (..)
 import Helpers.AccessEditor as AccessEditor
-import Helpers.Store as Store
 import Stores.Authorization exposing (Authorization, emptyAuthorization)
 
 
@@ -15,7 +14,6 @@ import Stores.Authorization exposing (Authorization, emptyAuthorization)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (..)
 import Helpers.AccessEditor as AccessEditor
 import Config
 import Helpers.Forms exposing (..)

--- a/client/Pages/EventTypeDetails/Messages.elm
+++ b/client/Pages/EventTypeDetails/Messages.elm
@@ -12,6 +12,7 @@ import Stores.EventTypeValidation
 import Stores.Query
 import Http
 import RemoteData exposing (WebData)
+import Pages.EventTypeDetails.PublishTab
 
 
 type Msg
@@ -42,10 +43,6 @@ type Msg
     | OutAddToFavorite String
     | OutRemoveFromFavorite String
     | ValidationStoreMsg Stores.EventTypeValidation.Msg
-    | EditEvent String
-    | SendEvent
-    | SendEventResponse (WebData String)
-    | SendEventReset
     | LoadQuery String
     | LoadQueryResponse (WebData Stores.Query.Query)
     | OpenDeleteQueryPopup
@@ -53,3 +50,4 @@ type Msg
     | ConfirmQueryDelete
     | QueryDelete
     | QueryDeleteResponse (WebData ())
+    | PublishTabMsg Pages.EventTypeDetails.PublishTab.Msg

--- a/client/Pages/EventTypeDetails/Models.elm
+++ b/client/Pages/EventTypeDetails/Models.elm
@@ -12,8 +12,8 @@ import Stores.EventTypeSchema
 import Stores.EventTypeValidation
 import Stores.Query exposing (Query)
 import Helpers.Store exposing (Status(Unknown), ErrorMessage)
-import Http
 import RemoteData exposing (WebData, RemoteData(NotAsked))
+import Pages.EventTypeDetails.PublishTab
 
 
 initialModel : Model
@@ -30,8 +30,6 @@ initialModel =
     , eventTypeSchemasStore = Stores.EventTypeSchema.initialModel
     , totalsStore = Stores.CursorDistance.initialModel
     , validationIssuesStore = Stores.EventTypeValidation.initialModel
-    , editEvent = emptyString
-    , sendEventResponse = NotAsked
     , loadQueryResponse = NotAsked
     , deletePopup =
         { isOpen = False
@@ -42,6 +40,7 @@ initialModel =
     , deleteQueryPopupOpen = False
     , deleteQueryPopupCheck = False
     , deleteQueryResponse = NotAsked
+    , publishTab = Pages.EventTypeDetails.PublishTab.initialModel
     }
 
 
@@ -68,8 +67,6 @@ type alias Model =
     , eventTypeSchemasStore : Stores.EventTypeSchema.Model
     , totalsStore : Stores.CursorDistance.Model
     , validationIssuesStore : Stores.EventTypeValidation.Model
-    , editEvent : String
-    , sendEventResponse : WebData String
     , loadQueryResponse : WebData Query
     , deletePopup :
         { isOpen : Bool
@@ -80,6 +77,7 @@ type alias Model =
     , deleteQueryPopupOpen : Bool
     , deleteQueryPopupCheck : Bool
     , deleteQueryResponse : WebData ()
+    , publishTab : Pages.EventTypeDetails.PublishTab.Model
     }
 
 

--- a/client/Pages/EventTypeDetails/QueryTab.elm
+++ b/client/Pages/EventTypeDetails/QueryTab.elm
@@ -12,7 +12,6 @@ import Helpers.Panel exposing (renderError, warningMessage)
 import Helpers.Store exposing (errorToViewRecord)
 import RemoteData exposing (WebData, isLoading)
 import Http
-import Json.Decode
 import Config
 import User.Models exposing (Settings)
 import String.Extra exposing (replace)

--- a/client/Pages/EventTypeDetails/Update.elm
+++ b/client/Pages/EventTypeDetails/Update.elm
@@ -22,6 +22,7 @@ import Http
 import Config
 import RemoteData exposing (isFailure, isSuccess, RemoteData(Loading, Failure, NotAsked))
 import User.Models exposing (Settings)
+import Pages.EventTypeDetails.PublishTab
 
 
 update : Settings -> Msg -> Model -> ( Model, Cmd Msg, Route )
@@ -232,17 +233,12 @@ update settings message model =
                     in
                         ( { model | validationIssuesStore = newSubModel }, Cmd.map ValidationStoreMsg newSubMsg )
 
-                EditEvent value ->
-                    ( { model | editEvent = value }, Cmd.none )
-
-                SendEvent ->
-                    ( model, sendEvent SendEventResponse model.name model.editEvent )
-
-                SendEventResponse value ->
-                    ( { model | sendEventResponse = value }, Cmd.none )
-
-                SendEventReset ->
-                    ( { model | sendEventResponse = NotAsked, editEvent = "" }, Cmd.none )
+                PublishTabMsg subMsg ->
+                    let
+                        ( newSubModel, newSubMsg ) =
+                            Pages.EventTypeDetails.PublishTab.update subMsg model.publishTab model.name
+                    in
+                        ( { model | publishTab = newSubModel }, Cmd.map PublishTabMsg newSubMsg )
 
                 OpenDeletePopup ->
                     let

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -278,7 +278,8 @@ detailsLayout typeName eventType model =
                             , if not isQueryOutput then
                                 [ ( PublishTab
                                   , "Publish Events"
-                                  , publishTab pageState
+                                  , publishTab pageState.publishTab
+                                        |> Html.map PublishTabMsg
                                   )
                                 ]
                               else

--- a/client/Pages/NotFound/View.elm
+++ b/client/Pages/NotFound/View.elm
@@ -1,11 +1,15 @@
 module Pages.NotFound.View exposing (..)
 
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
 import Models exposing (AppModel)
 import Types exposing (AppHtml)
-import Helpers.Panel exposing (page, panelWithButton)
+import Helpers.Panel exposing (page, panel)
 import Html exposing (text, Html)
 import Routing.Models exposing (Route(HomeRoute))
-
+import Routing.Messages exposing (Msg(Redirect))
+import Messages exposing (Msg(RoutingMsg))
 
 
 view : AppModel -> AppHtml
@@ -17,4 +21,15 @@ view model =
             [ text "Oops! Sorry, but the page you are looking for doesn't exist here." ]
             "Go to Home page"
             HomeRoute
+        ]
+
+
+panelWithButton : Int -> String -> List (Html Messages.Msg) -> String -> Route -> Html Messages.Msg
+panelWithButton gridSize title desc btnText route =
+    panel gridSize
+        title
+        [ p [] desc
+        , div [ class "dc--text-center" ]
+            [ button [ class "dc-btn dc-btn--primary dc--text-center", onClick (RoutingMsg (Redirect route)) ] [ text btnText ]
+            ]
         ]

--- a/client/assets/styles.css
+++ b/client/assets/styles.css
@@ -965,3 +965,8 @@ body {
     box-shadow: #ffe2ae 0 0 20px;
     transition: box-shadow 0.3s;
 }
+
+.flash-msg {
+    opacity: 0;
+    transition: opacity 1s 2s;
+}


### PR DESCRIPTION
- Refactor Event Publishing tab, make publish tab as independent sub-component of the event type details page.
- Add template with metadata (only for "business" ET fro now)
- Show publishing request status and hide "Success" message after 3s.